### PR TITLE
Add Gemini integration example

### DIFF
--- a/gemini_app/README.md
+++ b/gemini_app/README.md
@@ -1,0 +1,27 @@
+# Gemini App
+
+This simple command-line app demonstrates how to interact with the Gemini API using the `google-generativeai` library.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Export your Google API key:
+
+```bash
+export GOOGLE_API_KEY=your_api_key_here
+```
+
+## Usage
+
+Run the chat script:
+
+```bash
+python gemini_chat.py
+```
+
+Type your prompt and receive responses from the Gemini model. Type `exit` to quit.

--- a/gemini_app/gemini_chat.py
+++ b/gemini_app/gemini_chat.py
@@ -1,0 +1,26 @@
+import os
+import google.generativeai as genai
+
+
+def main():
+    api_key = os.environ.get("GOOGLE_API_KEY")
+    if not api_key:
+        raise RuntimeError("GOOGLE_API_KEY environment variable not set")
+
+    genai.configure(api_key=api_key)
+    model = genai.GenerativeModel("gemini-pro")
+
+    print("Type 'exit' to quit.")
+    while True:
+        try:
+            prompt = input("You> ")
+        except EOFError:
+            break
+        if prompt.strip().lower() == "exit":
+            break
+        response = model.generate_content(prompt)
+        print("Gemini>", response.text)
+
+
+if __name__ == "__main__":
+    main()

--- a/gemini_app/requirements.txt
+++ b/gemini_app/requirements.txt
@@ -1,0 +1,1 @@
+google-generativeai


### PR DESCRIPTION
## Summary
- add a simple CLI script to chat with Gemini
- document setup and usage
- specify the required Python package

## Testing
- `python -m py_compile gemini_app/gemini_chat.py`


------
https://chatgpt.com/codex/tasks/task_e_6885f69e1444832791c79d30ac9f4d99